### PR TITLE
Use --write instead of --apply

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/index.js",
 	"scripts": {
 		"build": "ncc build src/index.ts",
-		"biome:check": "biome check --apply .",
+		"biome:check": "biome check --write .",
 		"biome:ci": "biome ci .",
 		"tsc:check": "tsc --noEmit",
 		"test": "vitest"


### PR DESCRIPTION
When I ran `biome check --apply .`, I got a warning like this:

> ⚠ The argument --apply is deprecated, it will be removed in the next major release. Use --write instead.

This change just replaces `--apply` with `--write`.