### PR TITLE
Specify node24 in `using` (#2570)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: 24
           check-latest: true
           cache: npm
 

--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ branding:
   icon: bar-chart
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -30454,7 +30454,7 @@ const getAverage = (seconds) => {
 const getMedian = (seconds) => {
     const sortedSeconds = seconds.toSorted();
     const mid = Math.floor(sortedSeconds.length / 2);
-    // @ts-ignore
+    // @ts-expect-error
     return sortedSeconds[mid];
 };
 const getMin = (seconds) => Math.min(...seconds);


### PR DESCRIPTION
According to the release of GitHub Actions Runner, Node24 is available on GitHub-hosted runners.

https://github.com/actions/runner/releases/tag/v2.327.0

Like https://github.com/actions/checkout/releases/tag/v5.0.0, I want to use Node24 for this Action.