### PR TITLE
fix: Use client ID for app token workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary
Update the GitHub App token creation steps in CI and release workflows to use the recommended `client-id` input.

## Purpose
Remove the deprecation warning emitted by `actions/create-github-app-token@v3` for the legacy `app-id` input.

## Background
`actions/create-github-app-token@v3` now recommends identifying the GitHub App by its Client ID via `client-id`. The repository already has `APP_CLIENT_ID` configured as a variable, so we can transition away from the deprecated numeric App ID input.

## Changes
- Replace `app-id: ${{ vars.APP_ID }}` with `client-id: ${{ vars.APP_CLIENT_ID }}` in:
  - `.github/workflows/ci.yml`
  - `.github/workflows/release.yml`

## Out of Scope
No action version bumps or private key changes are included.

## Related
None

## Testing
- Verified that all workflow files reference `client-id: ${{ vars.APP_CLIENT_ID }}`.
- Verified no occurrences of `app-id` remain in `.github/workflows/`.
- Ran the test suite locally to ensure no regressions.

## Post-Release Verification
Confirm that the next run of the affected workflows succeeds and no longer outputs the `app-id` deprecation warning.

## Operational Notes
`vars.APP_CLIENT_ID` must remain configured in the repository's variables.
